### PR TITLE
chore: add kubectl v1.21.9 to release image

### DIFF
--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -25,6 +25,13 @@ RUN wget https://github.com/helm/chart-releaser/releases/download/v${CR_VERSION}
   && chmod +x /usr/local/bin/cr \
   && rm LICENSE README.md
 
+ARG KUBECTL_VERSION=v1.21.9
+RUN curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl \
+  && curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl.sha256 \
+  && echo "$(cat kubectl.sha256) kubectl" | sha256sum --check \
+  && chmod +x ./kubectl \
+  && mv ./kubectl /usr/local/bin
+
 # Cache repository, used frequently during chart releasing
 RUN helm repo add bitnami https://charts.bitnami.com/bitnami
 


### PR DESCRIPTION
Currently kubectl v1.22.12 is the latest release https://github.com/kubernetes/kubernetes/releases  which is only 1 minor version away from the server side (at v1.21.13): 
```
openoms_galoy_io@galoy-inc-bastion:~$ kubectl version
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.9", GitCommit:"b631974d68ac5045e076c86a5c66fba6f128dc72", GitTreeState:"clean", BuildDate:"2022-01-19T17:51:12Z", GoVersion:"go1.16.12", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.13-gke.900", GitCommit:"8f8dd9d389916c66dd26704a96f1ab4c5776f9df", GitTreeState:"clean", BuildDate:"2022-06-06T09:24:36Z", GoVersion:"go1.16.15b7", Compiler:"gc", Platform:"linux/amd64"}
```