### PR TITLE
Chore: mavapay working

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 1. Clone and get into the repository:
 
 ```
-gh repo clone GaloyMoney/concourse-shared
+gh repo clone blinkbitcoin/concourse-shared
 cd concourse-shared
 ```
 
-2. Edit `ci/values.yml` and under `src_repos`, add the new repository. The key name for the repository must be the name of the repository as on GitHub under GaloyMoney organization.
+2. Edit `ci/values.yml` and under `src_repos`, add the new repository. The key name for the repository must be the name of the repository as on GitHub under blinkbitcoin organization.
    This file contains many feature flags according to which the Pull Request will be created with shared tasks.
 3. Push the change on the CI.
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -26,15 +26,15 @@ groups:
 #@ for repo in data.values.src_repos:
   - #@ "bump-shared-files-in-" + repo
 #@ end
-- name: images
-  jobs:
-  - build-rust-concourse-image
-  - build-nodejs-concourse-image
-  - build-wincross-pipeline-image
-  - build-release-pipeline-image
-- name: backups
-  jobs:
-  - backup-org-to-gcp
+#! - name: images
+#!   jobs:
+#!   - build-rust-concourse-image
+#!   - build-nodejs-concourse-image
+#!   - build-wincross-pipeline-image
+#!   - build-release-pipeline-image
+#! - name: backups
+#!   jobs:
+#!   - backup-org-to-gcp
 
 #@ def build_task(input_name, context_path):
 task: build
@@ -62,43 +62,43 @@ config:
 #@ end
 
 jobs:
-- name: build-rust-concourse-image
-  serial: true
-  plan:
-  - {get: rust-image-def, trigger: true}
-  - #@ build_task("rust-image-def", "rust-image-def/images/rust-concourse")
-  - put: rust-image
-    params:
-      image: image/image.tar
+#! - name: build-rust-concourse-image
+#!   serial: true
+#!   plan:
+#!   - {get: rust-image-def, trigger: true}
+#!   - #@ build_task("rust-image-def", "rust-image-def/images/rust-concourse")
+#!   - put: rust-image
+#!     params:
+#!       image: image/image.tar
 
-- name: build-nodejs-concourse-image
-  serial: true
-  plan:
-  - {get: nodejs-image-def, trigger: true}
-  - #@ build_task("nodejs-image-def", "nodejs-image-def/images/nodejs-concourse")
-  - put: nodejs-image
-    params:
-      image: image/image.tar
+#! - name: build-nodejs-concourse-image
+#!   serial: true
+#!   plan:
+#!   - {get: nodejs-image-def, trigger: true}
+#!   - #@ build_task("nodejs-image-def", "nodejs-image-def/images/nodejs-concourse")
+#!   - put: nodejs-image
+#!     params:
+#!       image: image/image.tar
 
-- name: build-release-pipeline-image
-  serial: true
-  plan:
-  - get: release-pipeline-image-def
-    trigger: true
-  - #@ build_task("release-pipeline-image-def", "release-pipeline-image-def/images/release")
-  - put: release-pipeline-image
-    params:
-      image: image/image.tar
+#! - name: build-release-pipeline-image
+#!   serial: true
+#!   plan:
+#!   - get: release-pipeline-image-def
+#!     trigger: true
+#!   - #@ build_task("release-pipeline-image-def", "release-pipeline-image-def/images/release")
+#!   - put: release-pipeline-image
+#!     params:
+#!       image: image/image.tar
 
-- name: build-wincross-pipeline-image
-  serial: true
-  plan:
-  - get: wincross-pipeline-image-def
-    trigger: true
-  - #@ build_task("wincross-pipeline-image-def", "wincross-pipeline-image-def/images/wincross")
-  - put: wincross-pipeline-image
-    params:
-      image: image/image.tar
+#! - name: build-wincross-pipeline-image
+#!   serial: true
+#!   plan:
+#!   - get: wincross-pipeline-image-def
+#!     trigger: true
+#!   - #@ build_task("wincross-pipeline-image-def", "wincross-pipeline-image-def/images/wincross")
+#!   - put: wincross-pipeline-image
+#!     params:
+#!       image: image/image.tar
 
 
 #@ for repo in data.values.src_repos:
@@ -145,27 +145,29 @@ jobs:
         path: pipeline-tasks/ci/tasks/open-pr.sh
 #@ end
 
-- name: backup-org-to-gcp
-  plan:
-  - in_parallel:
-    - { get: every-day-trigger, trigger: true }
-    - { get: pipeline-tasks }
-  - task: gcp-backup
-    config:
-      platform: linux
-      image_resource: 
-        type: registry-image
-        source:
-          repository: us.gcr.io/galoy-org/galoy-dev
-      inputs:
-      - name: pipeline-tasks
-      params:
-        GOOGLE_CREDENTIALS: #@ data.values.staging_inception_creds 
-        GOOGLE_BUCKET_NAME: #@ data.values.staging_bucket_name
-        GH_APP_ID: #@ data.values.github_app_id
-        GH_APP_PRIVATE_KEY: #@ data.values.github_app_private_key
-      run:
-        path: pipeline-tasks/ci/tasks/gcp-backup.sh
+#! This is failing in the galoy-org version of the pipeline. Not sure what it's doing so deactivating for now.
+
+#! - name: backup-org-to-gcp
+#!   plan:
+#!   - in_parallel:
+#!     - { get: every-day-trigger, trigger: true }
+#!     - { get: pipeline-tasks }
+#!   - task: gcp-backup
+#!     config:
+#!       platform: linux
+#!       image_resource: 
+#!         type: registry-image
+#!         source:
+#!           repository: us.gcr.io/galoy-org/galoy-dev
+#!       inputs:
+#!       - name: pipeline-tasks
+#!       params:
+#!         GOOGLE_CREDENTIALS: #@ data.values.staging_inception_creds 
+#!         GOOGLE_BUCKET_NAME: #@ data.values.staging_bucket_name
+#!         GH_APP_ID: #@ data.values.github_app_id
+#!         GH_APP_PRIVATE_KEY: #@ data.values.github_app_private_key
+#!       run:
+#!         path: pipeline-tasks/ci/tasks/gcp-backup.sh
 
 resources:
 - name: shared-files
@@ -206,72 +208,72 @@ resources:
     branch: #@ data.values.source_repo_branch
 #@ end
 
-- name: nodejs-image-def
-  type: git
-  source:
-    paths: [images/nodejs-concourse/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
+#! - name: nodejs-image-def
+#!   type: git
+#!   source:
+#!     paths: [images/nodejs-concourse/Dockerfile]
+#!     uri: #@ data.values.git_uri
+#!     branch: #@ data.values.git_branch
+#!     private_key: #@ data.values.github_private_key
 
-- name: nodejs-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.docker_registry_user
-    password: #@ data.values.docker_registry_password
-    repository: #@ data.values.docker_registry + "/nodejs-concourse"
+#! - name: nodejs-image
+#!   type: registry-image
+#!   source:
+#!     tag: latest
+#!     username: #@ data.values.docker_registry_user
+#!     password: #@ data.values.docker_registry_password
+#!     repository: #@ data.values.docker_registry + "/nodejs-concourse"
 
-- name: rust-image-def
-  type: git
-  source:
-    paths: [images/rust-concourse/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
+#! - name: rust-image-def
+#!   type: git
+#!   source:
+#!     paths: [images/rust-concourse/Dockerfile]
+#!     uri: #@ data.values.git_uri
+#!     branch: #@ data.values.git_branch
+#!     private_key: #@ data.values.github_private_key
 
-- name: rust-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.docker_registry_user
-    password: #@ data.values.docker_registry_password
-    repository: #@ data.values.docker_registry + "/rust-concourse"
+#! - name: rust-image
+#!   type: registry-image
+#!   source:
+#!     tag: latest
+#!     username: #@ data.values.docker_registry_user
+#!     password: #@ data.values.docker_registry_password
+#!     repository: #@ data.values.docker_registry + "/rust-concourse"
 
-- name: release-pipeline-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.docker_registry_user
-    password: #@ data.values.docker_registry_password
-    repository: #@   data.values.docker_registry + "/release-pipeline"
+#! - name: release-pipeline-image
+#!   type: registry-image
+#!   source:
+#!     tag: latest
+#!     username: #@ data.values.docker_registry_user
+#!     password: #@ data.values.docker_registry_password
+#!     repository: #@   data.values.docker_registry + "/release-pipeline"
 
-- name: release-pipeline-image-def
-  type: git
-  source:
-    paths: [images/release/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
+#! - name: release-pipeline-image-def
+#!   type: git
+#!   source:
+#!     paths: [images/release/Dockerfile]
+#!     uri: #@ data.values.git_uri
+#!     branch: #@ data.values.git_branch
+#!     private_key: #@ data.values.github_private_key
 
-- name: wincross-pipeline-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.docker_registry_user
-    password: #@ data.values.docker_registry_password
-    repository: #@   data.values.docker_registry + "/wincross-rust"
+#! - name: wincross-pipeline-image
+#!   type: registry-image
+#!   source:
+#!     tag: latest
+#!     username: #@ data.values.docker_registry_user
+#!     password: #@ data.values.docker_registry_password
+#!     repository: #@   data.values.docker_registry + "/wincross-rust"
 
-- name: wincross-pipeline-image-def
-  type: git
-  source:
-    paths: [images/wincross/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
+#! - name: wincross-pipeline-image-def
+#!   type: git
+#!   source:
+#!     paths: [images/wincross/Dockerfile]
+#!     uri: #@ data.values.git_uri
+#!     branch: #@ data.values.git_branch
+#!     private_key: #@ data.values.github_private_key
 
-- name: every-day-trigger
-  type: time
-  icon: clock-outline
-  source:
-    interval: 24h
+#! - name: every-day-trigger
+#!   type: time
+#!   icon: clock-outline
+#!   source:
+#!     interval: 24h

--- a/ci/repipe
+++ b/ci/repipe
@@ -18,5 +18,5 @@ ytt -f ci > ${TMPDIR}/pipeline.yml
 
 echo "Updating pipeline @ ${target}"
 
-fly -t ${target} set-pipeline --team=${team} -p concourse-shared -c ${TMPDIR}/pipeline.yml
-fly -t ${target} unpause-pipeline --team=${team} -p concourse-shared
+fly -t ${target} set-pipeline --team=${team} -p blink-concourse-shared -c ${TMPDIR}/pipeline.yml
+fly -t ${target} unpause-pipeline --team=${team} -p blink-concourse-shared

--- a/ci/tasks/gcp-backup.sh
+++ b/ci/tasks/gcp-backup.sh
@@ -3,7 +3,7 @@
 set -eu
 
 CI_ROOT=$(pwd)
-ORG_NAME="GaloyMoney"
+ORG_NAME="blinkbitcoin"
 
 cat <<EOF > ${CI_ROOT}/gcloud-creds.json
 ${GOOGLE_CREDENTIALS}

--- a/ci/tasks/open-pr.sh
+++ b/ci/tasks/open-pr.sh
@@ -18,4 +18,4 @@ gh pr create \
   --body-file ../body.md \
   --base ${BRANCH} \
   --head ${PR_BRANCH} \
-  --label galoybot
+  --label blinkbitcoinbot

--- a/ci/tasks/open-pr.sh
+++ b/ci/tasks/open-pr.sh
@@ -9,7 +9,7 @@ pushd source-repo
 cat <<EOF >> ../body.md
 # Bump Shared Tasks
 
-This PR syncs in this repository, shared CI tasks from [concourse-shared](https://github.com/GaloyMoney/concourse-shared).
+This PR syncs in this repository, shared CI tasks from [concourse-shared](https://github.com/blinkbitcoin/concourse-shared).
 EOF
 
 gh pr close ${PR_BRANCH} || true

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -2,11 +2,11 @@
 ---
 
 git_uri: git@github.com:blinkbitcoin/concourse-shared.git
-git_branch: main
+git_branch: kn/mavapay_working
 github_private_key: ((github-blinkbitcoin.private_key))
 github_token: ((github-blinkbitcoin.api_token))
 github_app_id: ((github-blinkbitcoin.github_app_id))
-github_app_private_key: ((github-blinkbitcoinb.github_app_private_key))
+github_app_private_key: ((github-blinkbitcoin.github_app_private_key))
 
 docker_registry: us.gcr.io/galoy-org
 docker_registry_user: ((docker-creds.username))
@@ -20,16 +20,4 @@ pr_branch: bump-shared-tasks
 source_repo_branch: main
 
 src_repos:
-  galoy: ["nodejs", "docker", "chart"]
-  stablesats-rs: ["rust", "docker", "chart"]
-  proof-of-sats: ["nodejs", "docker", "chart"]
-  galoy-cli: ["rust"]
-  sqlxmq-executor: ["rust", "docker"]
-  bria: ["rust", "docker", "chart"]
-  cala: ["rust", "docker"]
-  cala-enterprise: ["rust", "docker"]
-  lana-bank: ["rust", "docker"]
-  galoy-mobile: ["nodejs"]
-  blink-circles: ["nodejs", "docker", "chart"]
-  blink-fiat: ["nodejs", "docker", "chart"]
-  blink-kyc: ["nodejs", "docker", "chart"]
+  mavapay-clinet: ["nodejs"]

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -20,4 +20,4 @@ pr_branch: bump-shared-tasks
 source_repo_branch: main
 
 src_repos:
-  mavapay-clinet: ["nodejs"]
+  mavapay-client: ["nodejs"]

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -1,12 +1,12 @@
 #@data/values
 ---
 
-git_uri: git@github.com:GaloyMoney/concourse-shared.git
+git_uri: git@github.com:blinkbitcoin/concourse-shared.git
 git_branch: main
-github_private_key: ((github.private_key))
-github_token: ((github.api_token))
-github_app_id: ((github.github_app_id))
-github_app_private_key: ((github.github_app_private_key))
+github_private_key: ((github-blinkbitcoin.private_key))
+github_token: ((github-blinkbitcoin.api_token))
+github_app_id: ((github-blinkbitcoin.github_app_id))
+github_app_private_key: ((github-blinkbitcoinb.github_app_private_key))
 
 docker_registry: us.gcr.io/galoy-org
 docker_registry_user: ((docker-creds.username))
@@ -15,7 +15,7 @@ container_image: galoy-dev
 staging_inception_creds: ((staging-gcp-creds.creds_json))
 staging_bucket_name: galoy-staging-backups
 
-git_org_uri: git@github.com:GaloyMoney
+git_org_uri: git@github.com:blinkbitcoin
 pr_branch: bump-shared-tasks
 source_repo_branch: main
 

--- a/shared/actions/nodejs-audit.yml
+++ b/shared/actions/nodejs-audit.yml
@@ -1,5 +1,5 @@
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 name: Audit
 

--- a/shared/actions/nodejs-check-code.yml
+++ b/shared/actions/nodejs-check-code.yml
@@ -1,5 +1,5 @@
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 name: Check Code
 

--- a/shared/actions/rust-audit.yml
+++ b/shared/actions/rust-audit.yml
@@ -1,5 +1,5 @@
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 name: Audit
 

--- a/shared/actions/rust-check-code.yml
+++ b/shared/actions/rust-check-code.yml
@@ -1,5 +1,5 @@
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 name: Check Code
 

--- a/shared/actions/spelling.yml
+++ b/shared/actions/spelling.yml
@@ -1,5 +1,5 @@
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 name: Spelling
 

--- a/shared/ci/config/git-cliff.toml
+++ b/shared/ci/config/git-cliff.toml
@@ -1,5 +1,5 @@
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 # configuration file for git-cliff (0.1.0)
 

--- a/shared/ci/config/nodejs-dependabot.yml
+++ b/shared/ci/config/nodejs-dependabot.yml
@@ -1,5 +1,5 @@
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.

--- a/shared/ci/config/rust-dependabot.yml
+++ b/shared/ci/config/rust-dependabot.yml
@@ -1,5 +1,5 @@
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.

--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -448,11 +448,17 @@ source:
   repository: #@ public_docker_registry() + "/" + data.values.gh_repository if publicRepo else private_docker_registry() + "/" + data.values.gh_repository
 #@ end
 
-#@ def nodejs_deps_resource(webhook = False):
+#@ def nodejs_deps_resource(webhook = False, pckgMgr = "yarn"):
 name: deps
 type: git
 source:
+#@ if pckgMgr == "yarn":
   paths: [yarn.lock]
+#@ elif pckgMgr == "pnpm":
+  paths: [pnpm-lock.yaml]
+#@ else:
+#@     assert.fail("unsupported package manager: " + pckgMgr)
+#@ end
   uri: #@ data.values.git_uri
   branch: #@ data.values.git_branch
   private_key: #@ data.values.github_private_key

--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -540,7 +540,7 @@ source:
 name: docker-host
 type: pool
 source:
-  uri: git@github.com:GaloyMoney/concourse-locks.git
+  uri: git@github.com:blinkbitcoin/concourse-locks.git
   branch: main
   pool: docker-hosts
   private_key: #@ data.values.github_private_key

--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -1,5 +1,5 @@
 #@ load("@ytt:data", "data")
-
+#@ load("@ytt:assert", "assert")
 #@ def public_docker_registry():
 #@  return "us.gcr.io/galoy-org"
 #@ end

--- a/shared/ci/tasks/cache-pnpm-deps.sh
+++ b/shared/ci/tasks/cache-pnpm-deps.sh
@@ -7,7 +7,7 @@ tar_out="$(pwd)/bundled-deps"
 pushd deps
 # Install dependencies
 echo "    --> pnpm install"
-pnpm install --shamefully-hoist
+pnpm install --no-store # --shamefully-hoist
 
 # Get git reference for versioning
 echo "    --> git log"
@@ -18,7 +18,7 @@ output_file="${tar_out}/bundled-deps-v$(cat ../deps-version/number)-$(cat gitref
 
 # Use --dereference to convert hard links to regular files
 echo "    --> tar ..."
-tar --dereference -zcf "$output_file" \
+tar -zcf "$output_file" \
     --exclude='.git' \
     --exclude='.github' \
     --exclude='ci' \

--- a/shared/ci/tasks/cache-pnpm-deps.sh
+++ b/shared/ci/tasks/cache-pnpm-deps.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+
+tar_out="$(pwd)/bundled-deps"
+
+pushd deps
+# Install dependencies
+echo "    --> pnpm install"
+pnpm install --shamefully-hoist
+
+# Get git reference for versioning
+echo "    --> git log"
+git log --pretty=format:'%h' -n 1 > gitref
+
+# Create the output filename
+output_file="${tar_out}/bundled-deps-v$(cat ../deps-version/number)-$(cat gitref).tgz"
+
+# Use --dereference to convert hard links to regular files
+echo "    --> tar ..."
+tar --dereference -zcf "$output_file" \
+    --exclude='.git' \
+    --exclude='.github' \
+    --exclude='ci' \
+    .
+
+echo "    --> Done!"
+popd

--- a/shared/ci/tasks/chart-open-charts-pr.sh
+++ b/shared/ci/tasks/chart-open-charts-pr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/chart-test-integration.sh
+++ b/shared/ci/tasks/chart-test-integration.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/check-code.sh
+++ b/shared/ci/tasks/check-code.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/docker-bump-image-digest.sh
+++ b/shared/ci/tasks/docker-bump-image-digest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/docker-prep-docker-build-env.sh
+++ b/shared/ci/tasks/docker-prep-docker-build-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 if [[ -f version/version ]]; then
   echo "VERSION=$(cat version/version)" >> repo/.env

--- a/shared/ci/tasks/nodejs-audit.sh
+++ b/shared/ci/tasks/nodejs-audit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/nodejs-audit.sh
+++ b/shared/ci/tasks/nodejs-audit.sh
@@ -11,7 +11,15 @@ LEVEL=${LEVEL:-high}
 pushd ${REPO_ROOT}
 
 set +e
-yarn audit --groups dependencies --level ${LEVEL}
+if [[ -f ./yarn.lock ]]; then
+  yarn audit --groups dependencies --level ${LEVEL}
+elif [[ -f ./pnpm-lock.yaml ]]; then
+  pnpm audit --prod --audit-level=${LEVEL}
+else 
+  echo "Failed audit: Unsupported PckgMgr"
+  exit 2
+fi
+
 audit_return=$?
 set -e
 

--- a/shared/ci/tasks/nodejs-cache-yarn-deps.sh
+++ b/shared/ci/tasks/nodejs-cache-yarn-deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/nodejs-check-code.sh
+++ b/shared/ci/tasks/nodejs-check-code.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/nodejs-helpers.sh
+++ b/shared/ci/tasks/nodejs-helpers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 if [[ -z $(git config --global user.email) ]]; then
   git config --global user.email "bot@galoy.io"

--- a/shared/ci/tasks/nodejs-helpers.sh
+++ b/shared/ci/tasks/nodejs-helpers.sh
@@ -34,7 +34,7 @@ function unpack_deps() {
 
     pushd ${REPO_PATH} > /dev/null
 
-    tar -zxvf ../bundled-deps/bundled-deps-*.tgz ./node_modules/ ./pnpm-lock.yaml ./.pnpm-store > /dev/null
+    tar -zxvf ../bundled-deps/bundled-deps-*.tgz ./node_modules/ ./pnpm-lock.yaml > /dev/null
 
     if [[ "$(git status -s -uno)" != "" ]]; then
       echo "Extracting deps has created a diff - deps are not in sync"

--- a/shared/ci/tasks/nodejs-helpers.sh
+++ b/shared/ci/tasks/nodejs-helpers.sh
@@ -14,7 +14,7 @@ function unpack_deps() {
   REPO_PATH=${REPO_PATH:-repo}
 
   if [[ -f ${REPO_PATH}/yarn.lock ]]; then
-    echo "Unpacking nodejs deps... "
+    echo "    --> Unpacking nodejs deps... (yarn)"
 
     pushd ${REPO_PATH} > /dev/null
 
@@ -26,10 +26,41 @@ function unpack_deps() {
       exit 1;
     fi
 
-    echo "Done!"
+    echo "    --> Done!"
 
     popd
+  elif [[ -f ${REPO_PATH}/pnpm-lock.yaml ]]; then
+    echo "    --> Unpacking nodejs deps... (pnpm)"
+
+    pushd ${REPO_PATH} > /dev/null
+
+    tar -zxvf ../bundled-deps/bundled-deps-*.tgz ./node_modules/ ./pnpm-lock.yaml ./.pnpm-store > /dev/null
+
+    if [[ "$(git status -s -uno)" != "" ]]; then
+      echo "Extracting deps has created a diff - deps are not in sync"
+      git --no-pager diff
+      exit 1;
+    fi
+
+    echo "    --> Done!"
+    popd
   else
-    echo "Skipping unpack deps"
+    echo "    --> Skipping unpack deps"
+  fi
+}
+
+function check_code() {
+  if [[ -f ${REPO_PATH}/yarn.lock ]]; then
+    echo "Checking code... (yarn)"
+    yarn code:check
+    echo "Done!"
+  elif [[ -f ${REPO_PATH}/pnpm-lock.yaml ]]; then
+    echo "    --> Checking code... (pnpm)"
+    pushd ${REPO_PATH} > /dev/null
+    pnpm code:check
+    echo "    --> Done!"
+    popd
+  else 
+    echo "    --> Skipping check code"
   fi
 }

--- a/shared/ci/tasks/nodejs-update-package-json.sh
+++ b/shared/ci/tasks/nodejs-update-package-json.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+# ----------- UPDATE REPO -----------
+git config --global user.email "bot@galoy.io"
+git config --global user.name "CI Bot"
+
+pushd repo
+
+jq --arg v "$(cat ../version/version)" '.version = $v' package.json > ../tmp && mv ../tmp package.json
+
+git add package.json
+git status
+
+if [[ "$(git status -s -uno)" != ""  ]]; then
+  git commit -m "ci(release): release version $(cat ../version/version)"
+fi

--- a/shared/ci/tasks/prep-release-src.sh
+++ b/shared/ci/tasks/prep-release-src.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/rust-check-code.sh
+++ b/shared/ci/tasks/rust-check-code.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 set -eu
 

--- a/shared/ci/tasks/rust-helpers.sh
+++ b/shared/ci/tasks/rust-helpers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #! Auto synced from Shared CI Resources repository
-#! Don't change this file, instead change it in github.com/GaloyMoney/concourse-shared
+#! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 if [[ -z $(git config --global user.email) ]]; then
   git config --global user.email "bot@galoy.io"

--- a/vendir.tmpl.yml
+++ b/vendir.tmpl.yml
@@ -7,7 +7,7 @@ directories:
   contents:
   - path: . # Copy this folder out to ..
     git:
-      url: https://github.com/GaloyMoney/concourse-shared.git
+      url: https://github.com/blinkbitcoin/concourse-shared.git
       ref: main
     includePaths:
     - shared/actions/*
@@ -22,7 +22,7 @@ directories:
   contents:
   - path: .
     git:
-      url: https://github.com/GaloyMoney/concourse-shared.git
+      url: https://github.com/blinkbitcoin/concourse-shared.git
       ref: main
     includePaths:
     - shared/ci/**/*


### PR DESCRIPTION
This is the first "payload-PR" for blinkbitcoin`s concourse-shared repo. It's a fork og galoy's concourse-shared repo and it needs to avoid unwanted interdependences. The ORIGINAL repo solves those purposes:
* It [builds](https://ci.blink.sv/teams/dev/pipelines/concourse-shared?group=images) a couple of images  for specific ci-related usecases (rust/nodejs/releasing and win-cross compiling)
* It creates a backup of all the repos (currently broken)
* It updates it's dependendent repos via PRs

So forking that repo is easy but getting it to work is not trivial. So, this PR:
* focuses on the necessity of the mavapay pipeline and therefore ...
* ... deactivates the first two use-cases 
* it also deactivates updates to all the repos the original repo does. That makes it possible that we can a bit more bold with changes

ToDo:

- [ ] Maybe get the backup working again for the blinkbitcoin-repos
- [ ] Remove the [massaging](https://github.com/blinkbitcoin/concourse-shared/blob/main/ci/tasks/bump-shared-files.sh#L26-L42) of the repos after the `vendir sync` which is counterintuitive and makes understanding and a workflow much more difficult
- [ ] include galoy-client to the repos to update

